### PR TITLE
Fixes #3

### DIFF
--- a/godirect/__init__.py
+++ b/godirect/__init__.py
@@ -10,7 +10,7 @@ class GoDirect:
 	interact with Vernier GoDirect devices.
 	"""
 
-	VERSION = "1.0.3"
+	VERSION = "1.0.4"
 
 	BLE_AUTO_CONNECT_RSSI_THRESHOLD = -50  #closer to zero is a stronger signal
 

--- a/godirect/device.py
+++ b/godirect/device.py
@@ -302,8 +302,11 @@ class GoDirectDevice(ABC):
 			testMask = testMask << 1;
 		return True
 
-	def _GDX_dec_rolling_counter(self):
+	def _GDX_dec_rolling_counter(self):	
 		self._rolling_counter -= 1
+		# Roll over to behave like an unsigned byte
+		if self._rolling_counter == -1:
+			self._rolling_counter = 0xFF
 		return self._rolling_counter
 
 	def _GDX_calculate_checksum(self, buff):

--- a/godirect/device.py
+++ b/godirect/device.py
@@ -302,7 +302,7 @@ class GoDirectDevice(ABC):
 			testMask = testMask << 1;
 		return True
 
-	def _GDX_dec_rolling_counter(self):	
+	def _GDX_dec_rolling_counter(self):
 		self._rolling_counter -= 1
 		# Roll over to behave like an unsigned byte
 		if self._rolling_counter == -1:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="godirect",
-    version="1.0.3",
+    version="1.0.4",
     author="Vernier Software and Technology",
     author_email="info@vernier.com",
     description="Library to interface with GoDirect devices via USB and BLE",


### PR DESCRIPTION
Fixes #3. After 255 writes, the rolling counter was decremented to -1. As there are no unsigned types, we need to force the counter back to 0xFF upon the rollover.