### PR TITLE
Switch to bleak, rather than vernierpygatt. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ automatically as dependencies when installing `godirect` via pip.
 
 The following Python modules are recommended for `godirect`. They will only be installed if they are specified as `extras` when installing `godirect` via pip. See below.
 
-* vernierpygatt (fork of the pygatt project with a fix for the BGAPI on Windows)
+* bleak (native Bluetooth Low Energy stack for Mac, Windows and Linux)
 * hidapi (USB HID device support)
 
 ## Installation
@@ -23,9 +23,9 @@ Automatically install the `extras` support dependencies for both USB and BLE.
 pip install godirect[usb,ble]
 ```
 
-In order to use the native Windows 10 or Linux BLE stack, Bleak must be installed.  To install:
+In order to use the Bluegiga BLE dongle, vernierpygatt must be installed. This is a fork of the pygatt project with a fix for the BGAPI on Windows. To install:
 ```bash
-pip install bleak
+pip install vernierpygatt
 ```
 
 ## Installation and Usage

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The following Python modules are recommended for `godirect`. They will only be i
 
 ## Installation
 
-Automatically install the `extras` support dependencies for both USB and BLE.
+Automatically install all the dependencies for both USB and native BLE.
 ```bash
-pip install godirect[usb,ble]
+pip install godirect
 ```
 
 In order to use the Bluegiga BLE dongle, vernierpygatt must be installed. This is a fork of the pygatt project with a fix for the BGAPI on Windows. To install:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,14 @@
 # godirect
 
-A Python module for reading from [Vernier Go Direct® Sensors](https://www.vernier.com/products/sensors/go-direct-sensors/) using USB or BLE.
+A Python module for reading from [Vernier Go Direct® Sensors](https://www.vernier.com/products/sensors/go-direct-sensors/) connected to USB or your system's on-board bluetooth radio. The module has been tested on Windows 10, macOS, and various Linux distros.
 
-Take a look at the [godirect-examples repository](https://github.com/VernierST/godirect-examples) for ideas and a number of helpful examples.
+Take a look at the [godirect-examples repository](https://github.com/VernierST/godirect-examples/tree/master/python) for ideas and a number of helpful examples.
 
 ## Requirements
 
-The following Python modules are required for `godirect`. They will be installed
-automatically as dependencies when installing `godirect` via pip.
+The following Python modules are required for `godirect`. They will be installed automatically as dependencies when installing `godirect` via pip.
 
 * pexpect
-
-The following Python modules are recommended for `godirect`. They will only be installed if they are specified as `extras` when installing `godirect` via pip. See below.
-
 * bleak (native Bluetooth Low Energy stack for Mac, Windows and Linux)
 * hidapi (USB HID device support)
 
@@ -23,14 +19,16 @@ Automatically install all the dependencies for both USB and native BLE.
 pip install godirect
 ```
 
-In order to use the Bluegiga BLE dongle, vernierpygatt must be installed. This is a fork of the pygatt project with a fix for the BGAPI on Windows. To install:
-```bash
-pip install vernierpygatt
-```
-
 ## Installation and Usage
 
 Go to our [Getting Started with Vernier Go Direct Sensors and Python document](https://github.com/VernierST/godirect-examples/blob/master/python/readme.md) for detailed information regarding installation and usage of the godirect module.
+
+## Legacy Support for Bluegiga Dongle
+
+Prior to version 1.1.0, some platforms required a Bluegiga BLE dongle to connect over BLE. While we recommend using the native BLE radio (through bleak), the old functionality has been left in the library. In order to use the Bluegiga BLE dongle, vernierpygatt must be installed. This is a fork of the pygatt project with a fix for the BGAPI on Windows. To install:
+```bash
+pip install vernierpygatt
+```
 
 ## License
 

--- a/docs/godirect.backend_bleak.html
+++ b/docs/godirect.backend_bleak.html
@@ -19,8 +19,7 @@
 <tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
 <td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="asyncio.html">asyncio</a><br>
 </td><td width="25%" valign=top><a href="logging.html">logging</a><br>
-</td><td width="25%" valign=top><a href="pygatt.html">pygatt</a><br>
-</td><td width="25%" valign=top></td></tr></table></td></tr></table><p>
+</td><td width="25%" valign=top></td><td width="25%" valign=top></td></tr></table></td></tr></table><p>
 <table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
 <tr bgcolor="#ee77aa">
 <td colspan=3 valign=bottom>&nbsp;<br>

--- a/docs/godirect.html
+++ b/docs/godirect.html
@@ -50,17 +50,17 @@
 <tr bgcolor="#ffc8d8"><td rowspan=2><tt>&nbsp;&nbsp;&nbsp;</tt></td>
 <td colspan=2><tt><a href="#GoDirect">GoDirect</a>(use_ble=True,&nbsp;use_ble_bg=False,&nbsp;use_usb=True,&nbsp;ble_com_port=None)<br>
 &nbsp;<br>
-The&nbsp;godirect&nbsp;module&nbsp;wraps&nbsp;the&nbsp;hidapi&nbsp;and&nbsp;pygatt&nbsp;modules&nbsp;to&nbsp;create&nbsp;an&nbsp;easy&nbsp;way&nbsp;to<br>
+The&nbsp;godirect&nbsp;module&nbsp;wraps&nbsp;the&nbsp;hidapi&nbsp;and&nbsp;bleak&nbsp;modules&nbsp;to&nbsp;create&nbsp;an&nbsp;easy&nbsp;way&nbsp;to<br>
 interact&nbsp;with&nbsp;Vernier&nbsp;<a href="#GoDirect">GoDirect</a>&nbsp;devices.<br>&nbsp;</tt></td></tr>
 <tr><td>&nbsp;</td>
 <td width="100%">Methods defined here:<br>
 <dl><dt><a name="GoDirect-__init__"><strong>__init__</strong></a>(self, use_ble=True, use_ble_bg=False, use_usb=True, ble_com_port=None)</dt><dd><tt>Construct&nbsp;a&nbsp;new&nbsp;'<a href="#GoDirect">GoDirect</a>'&nbsp;<a href="builtins.html#object">object</a>&nbsp;and&nbsp;initialize&nbsp;backends<br>
 &nbsp;<br>
-Uses&nbsp;Bleak&nbsp;if&nbsp;found,&nbsp;otherwise&nbsp;vernierpygatt&nbsp;BGAPI&nbsp;for&nbsp;BLE.&nbsp;HIDAPI&nbsp;is&nbsp;used&nbsp;for&nbsp;USB.<br>
+Uses&nbsp;Bleak&nbsp;for&nbsp;BLE.&nbsp;HIDAPI&nbsp;is&nbsp;used&nbsp;for&nbsp;USB.<br>
 &nbsp;<br>
 Args:<br>
 use_ble&nbsp;(bool):&nbsp;set&nbsp;to&nbsp;False&nbsp;to&nbsp;disable&nbsp;the&nbsp;BLE&nbsp;backend<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;use_ble_bg&nbsp;(bool):&nbsp;manual&nbsp;override&nbsp;to&nbsp;force&nbsp;use&nbsp;of&nbsp;BlueGiga&nbsp;over&nbsp;Bleak<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;use_ble_bg&nbsp;(bool):&nbsp;manual&nbsp;override&nbsp;to&nbsp;force&nbsp;use&nbsp;of&nbsp;BlueGiga&nbsp;(vernierpygatt&nbsp;over&nbsp;Bleak)<br>
 use_usb&nbsp;(bool):&nbsp;set&nbsp;to&nbsp;False&nbsp;to&nbsp;disable&nbsp;the&nbsp;USB&nbsp;backend<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ble_com_port&nbsp;(str):&nbsp;set&nbsp;to&nbsp;a&nbsp;COM&nbsp;port&nbsp;to&nbsp;override&nbsp;the&nbsp;auto&nbsp;detection&nbsp;in&nbsp;windows,&nbsp;e.g.&nbsp;'COM9'<br>
 Returns:<br>
@@ -102,7 +102,7 @@ Data descriptors defined here:<br>
 Data and other attributes defined here:<br>
 <dl><dt><strong>BLE_AUTO_CONNECT_RSSI_THRESHOLD</strong> = -50</dl>
 
-<dl><dt><strong>VERSION</strong> = '1.0.6'</dl>
+<dl><dt><strong>VERSION</strong> = '1.1.0'</dl>
 
 </td></tr></table></td></tr></table>
 </body></html>

--- a/godirect/__init__.py
+++ b/godirect/__init__.py
@@ -8,22 +8,22 @@ from .sensor import GoDirectSensor
 from .backend import GoDirectBackend
 
 class GoDirect:
-	""" The godirect module wraps the hidapi and pygatt modules to create an easy way to
+	""" The godirect module wraps the hidapi and bleak modules to create an easy way to
 	interact with Vernier GoDirect devices.
 	"""
 
-	VERSION = "1.0.7"
+	VERSION = "1.1.0"
 
 	BLE_AUTO_CONNECT_RSSI_THRESHOLD = -50  #closer to zero is a stronger signal
 
 	def __init__(self, use_ble=True, use_ble_bg=False, use_usb=True, ble_com_port=None):
 		""" Construct a new 'GoDirect' object and initialize backends
 		
-		Uses Bleak if found, otherwise vernierpygatt BGAPI for BLE. HIDAPI is used for USB.
+		Uses Bleak for BLE. HIDAPI is used for USB.
 
 		Args:
 	        use_ble (bool): set to False to disable the BLE backend
-			use_ble_bg (bool): manual override to force use of BlueGiga over Bleak
+			use_ble_bg (bool): manual override to force use of BlueGiga (vernierpygatt over Bleak)
         	use_usb (bool): set to False to disable the USB backend
 			ble_com_port (str): set to a COM port to override the auto detection in windows, e.g. 'COM9'
 		Returns:
@@ -35,10 +35,8 @@ class GoDirect:
 		self._usb_backend = None
 		self._devices = []
 		if use_ble == True:
-			bleak_spec = importlib.util.find_spec("bleak")
-			found_bleak = bleak_spec is not None
-			
-			if found_bleak and (platform.system() != 'Darwin') and use_ble_bg == False:
+
+			if use_ble_bg == False:
 				from .backend_bleak import GoDirectBackendBleak
 				self._ble_backend = GoDirectBackendBleak()
 			else:

--- a/godirect/backend_bleak.py
+++ b/godirect/backend_bleak.py
@@ -1,4 +1,3 @@
-import pygatt
 import logging
 from uuid import UUID
 import asyncio

--- a/godirect/device_bleak.py
+++ b/godirect/device_bleak.py
@@ -26,21 +26,15 @@ class GoDirectDeviceBleak(GoDirectDevice):
 		self._response_buffer = bytearray()
 		self._loop = asyncio.get_event_loop()
 		super().__init__(backend)
-
-	async def _async_is_connected(self):
-		return await self._device.is_connected()
 		
 	def is_connected(self):
 		""" Returns True if connected, False otherwise.
 		"""
-		if self._device != None:
-			if self._loop.run_until_complete(self._async_is_connected()):
-				return True
-		return False
+		return self._device.is_connected
 	
 	async def _async_connect(self):
 		await self._device.connect()
-		x = await self._device.is_connected()
+		x = self._device.is_connected
 		if not x:
 			return False
 			

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="godirect",
-    version="1.0.7",
+    version="1.1.0",
     author="Vernier Software and Technology",
     author_email="info@vernier.com",
     description="Library to interface with GoDirect devices via USB and BLE",
@@ -14,9 +14,10 @@ setuptools.setup(
     url="https://github.com/vernierst/godirect-py",
     packages=setuptools.find_packages(),
     install_requires=[
-        'pexpect'
+        'pexpect',
+        'hidapi',
+        'bleak'
     ],
-    extras_require={'usb': ["hidapi"], 'ble': ["vernierpygatt"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",


### PR DESCRIPTION
Switch to bleak for all platforms. This also makes the hidapi and bleak modules true dependencies, rather than optional.