### PR TITLE
Fixes some cases where the device name does not exist

### DIFF
--- a/godirect/backend_bleak.py
+++ b/godirect/backend_bleak.py
@@ -20,7 +20,7 @@ class GoDirectBackendBleak(GoDirectBackend):
 		devices = []
 		bleak_devices = await discover()
 		for d in bleak_devices:
-			if d.name[0:3] == 'GDX':
+			if d and d.name and d.name[0:3] == 'GDX':
 				device = GoDirectDeviceBleak(self)
 				device.id = d.address
 				device.type = "BLE"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="godirect",
-    version="1.1.2",
+    version="1.1.3",
     author="Vernier Software and Technology",
     author_email="info@vernier.com",
     description="Library to interface with GoDirect devices via USB and BLE",


### PR DESCRIPTION
Tom Smith was setting up a bunch of Windows workshop computers and was getting consistent crashes during the ble scan (using bleak). I am not sure why it was only happening on his hardware, but it could be related to memory management. In any case, the fix is to simply test that the name exists before trying to test the 0-3 characters.

We tested this on his machine and also published the 1.1.3 version already. 🥇 
