### PR TITLE
Fixes #31. Bleak deprecated the old discovery method

### DIFF
--- a/godirect/__init__.py
+++ b/godirect/__init__.py
@@ -12,7 +12,7 @@ class GoDirect:
 	interact with Vernier GoDirect devices.
 	"""
 
-	VERSION = "1.1.4"
+	VERSION = "1.2.0"
 
 	BLE_AUTO_CONNECT_RSSI_THRESHOLD = -50  #closer to zero is a stronger signal
 

--- a/godirect/backend_bleak.py
+++ b/godirect/backend_bleak.py
@@ -1,7 +1,9 @@
 import logging
 from uuid import UUID
 import asyncio
-from bleak import discover
+from bleak import BleakScanner
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
 
 from .backend import GoDirectBackend
 from .device_bleak import GoDirectDeviceBleak
@@ -18,14 +20,14 @@ class GoDirectBackendBleak(GoDirectBackend):
 
 	async def _async_scan(self):
 		devices = []
-		bleak_devices = await discover()
-		for d in bleak_devices:
-			if d and d.name and d.name[0:3] == 'GDX':
+		bleak_devices = await BleakScanner.discover(return_adv=True, timeout=3.5)
+		for d, a in bleak_devices.values():			
+			if d and a and d.name and d.name[0:3] == 'GDX':
 				device = GoDirectDeviceBleak(self)
 				device.id = d.address
 				device.type = "BLE"
 				device.set_name_from_advertisement(d.name)
-				device.rssi = d.rssi
+				device.rssi = a.rssi
 				devices.append(device)
 		return devices
 		

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="godirect",
-    version="1.1.4",
+    version="1.2.0",
     author="Vernier Software and Technology",
     author_email="info@vernier.com",
     description="Library to interface with GoDirect devices via USB and BLE",


### PR DESCRIPTION
Bleak deprecated the old discovery method in favor of BleakScanner.discover. Requires update to pip installed bleak. Minimum recommend version is latest version 1.0.1, as of this commit.

This has only been tested on Mac so far.